### PR TITLE
Setting customText of standardized value to user input

### DIFF
--- a/birch-typeahead.html
+++ b/birch-typeahead.html
@@ -624,7 +624,7 @@ Custom property | Description | Default
 
         if(e && e.type === 'mouseover') return;
         var selection = this.options[index];
-        this.value = selection.label;
+        selection.customText = this.value;
         this.fire('birch-typeahead:selected', {
           selection: selection,
           selectionIndex: index,


### PR DESCRIPTION
This will prevent user entered text from being lost when they type fast and hit tab before updated standardized list is returned.