### PR TITLE
Allowing the text within typeahead to be clicked

### DIFF
--- a/birch-typeahead.html
+++ b/birch-typeahead.html
@@ -599,7 +599,7 @@ Custom property | Description | Default
         if(!e) return;
 
         var counter = 0;
-        var el = Polymer.dom(e).rootTarget;
+        var el = Polymer.dom(e).localTarget;
         if(!this.$.optionsContainer.contains(el)) return;
 
         // This is necessary to acommidate shady dom.


### PR DESCRIPTION
- Previously the `rootTarget` would be a `slot` tag if the text was clicked (rather than the `paper-icon-item`)
- Changing to `localTarget` allows the box around the text, or the text itself to return the `paper-icon-item`