### PR TITLE
Fix an undefined object reference to parent.classList.

### DIFF
--- a/birch-typeahead.html
+++ b/birch-typeahead.html
@@ -610,7 +610,7 @@ Custom property | Description | Default
           counter++;
           if(counter === 9) break;
           var parent = el.parentNode;
-          if(parent.nodeName !== 'PAPER-LISTBOX'
+          if(parent.nodeName !== 'PAPER-LISTBOX' && parent.classList
             && !parent.classList.contains('selectable-content')){
             el = el.parentNode;
           } else {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-typeahead",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "authors": [
     "Anonymous <anonymous@example.com>"
   ],


### PR DESCRIPTION
Fix a bad reference to parent.classList reported by Sentry monitoring.  We fix it by first checking if parent.classList exists.  

We are noticing this on the places app but I believe it could happen anywhere the component is being used. 