### PR TITLE
bugfix: turn off automatic spelling correction on safari (TW-2271)

### DIFF
--- a/birch-typeahead.html
+++ b/birch-typeahead.html
@@ -232,6 +232,7 @@ Custom property | Description | Default
           data-test="EventInput"
           aria-label$="[[ariaInputLabel]]"
           autocomplete="off"
+          spellcheck="false"
           value="{{value::input}}"
           placeholder$="[[placeholder]]"
           autofocus$="[[autofocus]]"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-typeahead",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "authors": [
     "Anonymous <anonymous@example.com>"
   ],


### PR DESCRIPTION
- automatic spelling correction was preventing birch-standards-picker from selecting a standard, so we need to turn it off