### PR TITLE
feature: fire an event when the options list opens

### DIFF
--- a/birch-typeahead.html
+++ b/birch-typeahead.html
@@ -247,7 +247,7 @@ Custom property | Description | Default
           on-keydown="_handleKeydown"
           tabindex="-1"
           on-tap="_handleTap"
-          hidden$="[[_shouldHideOptions(_hideOptions, options)]]">
+          hidden$="[[_listCurrentlyHidden]]">
           <template is="dom-repeat" id="userTemplate" items="[[options]]"></template>
         </paper-listbox>
       </div>
@@ -421,6 +421,12 @@ Custom property | Description | Default
           value: false
         },
 
+        _listCurrentlyHidden: {
+          type: Boolean,
+          value: true,
+          observer: '_listCurrentlyHiddenObserver',
+        },
+
         isTabbing: {
           type: Boolean,
           value: false
@@ -431,6 +437,8 @@ Custom property | Description | Default
           value: false
         }
       },
+
+      observers: ['_shouldHideOptions(_hideOptions, options)'],
 
       /**
        * The ready function templatizes either the custom template provided
@@ -491,6 +499,7 @@ Custom property | Description | Default
       },
 
       _shouldHideOptions: function(hideOptions, options){
+        this._listCurrentlyHidden = hideOptions || options.length === 0;
         return hideOptions || options.length === 0;
       },
 
@@ -519,6 +528,12 @@ Custom property | Description | Default
           // to remain on the input field
           this.$.input.focus();
           this.showOptions();
+        }
+      },
+
+      _listCurrentlyHiddenObserver: function(newValue, oldValue) {
+        if (newValue === false && newValue !== oldValue) {
+          this.fire('birch-typeahead:list-opened')
         }
       },
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-typeahead",
-  "version": "2.5.5",
+  "version": "2.6.0",
   "authors": [
     "Anonymous <anonymous@example.com>"
   ],


### PR DESCRIPTION
* add a new property  so that we can accurately fire an event when the options menu has opened
* use the new property in the  attribute on the
* set the new property using an explicit observer rather than the observer getting created in the dom
* fire a new event when the options list has opened
* bump version

We will be using this event to scroll the standards list into view in the add flow if it is off screen.